### PR TITLE
Fix Ring&Weapon items sets count

### DIFF
--- a/src/FullRareSetManager/SetParts/RingItemsSetPart.cs
+++ b/src/FullRareSetManager/SetParts/RingItemsSetPart.cs
@@ -38,14 +38,14 @@ namespace FullRareSetManager.SetParts
 
             if (oneHandedLeft <= 0)
             {
-                return LowLvlItems.Count;
+                return LowLvlItems.Count / 2;
             }
             return HighLvlItems.Count + oneHandedLeft / 2; //(High & low) + (Low / 2)
         }
 
         public override int HighSetsCount()
         {
-            return HighLvlItems.Count;
+            return HighLvlItems.Count / 2;
         }
 
         public override string GetInfoString()

--- a/src/FullRareSetManager/SetParts/WeaponItemsSetPart.cs
+++ b/src/FullRareSetManager/SetParts/WeaponItemsSetPart.cs
@@ -44,28 +44,15 @@ namespace FullRareSetManager.SetParts
 
         public override int LowSetsCount()
         {
-            var count = TwoHandedLowLvlItems.Count;
+            var highLvlItemsToUse = Math.Min(OneHandedLowLvlItems.Count, OneHandedHighLvlItems.Count);
 
-            int oneHandedCount;
-
-            var oneHandedLeft = OneHandedLowLvlItems.Count - OneHandedHighLvlItems.Count; //High and low together
-
-            if (oneHandedLeft <= 0)
-            {
-                oneHandedCount = OneHandedLowLvlItems.Count;
-            }
-            else
-            {
-                oneHandedCount = OneHandedHighLvlItems.Count + oneHandedLeft / 2; //(High & low) + (Low / 2)
-            }
-
-
-            return count + oneHandedCount;
+            return TwoHandedLowLvlItems.Count +
+                   (OneHandedLowLvlItems.Count + highLvlItemsToUse) / 2;
         }
 
         public override int HighSetsCount()
         {
-            return TwoHandedHighLvlItems.Count + OneHandedHighLvlItems.Count;
+            return TwoHandedHighLvlItems.Count + OneHandedHighLvlItems.Count / 2;
         }
 
         public override int TotalSetsCount()


### PR DESCRIPTION
it fix a crash when there is only partial set because of rings/weapons.
the count returns a positive number for all item types, but then the code fails to find a full set and crash.