### PR TITLE
Fixed percentage value while no items at all

### DIFF
--- a/src/FullRareSetManager/Core.cs
+++ b/src/FullRareSetManager/Core.cs
@@ -584,7 +584,7 @@ namespace FullRareSetManager
                     var drawInfo = DisplayData[i];
 
                     if (drawInfo.TotalCount == 0)
-                        drawInfo.PriorityPercent = 1;
+                        drawInfo.PriorityPercent = 0;
                     else
                     {
                         drawInfo.PriorityPercent = (float)drawInfo.TotalCount / maxSets;


### PR DESCRIPTION
When you have set max sets to some value, and there is currently no items of that type in inv/chest, a percentage value was set to 100% instead of 0%.

The same problem may exist for multiple stash tabs, but i do not have enough for testing